### PR TITLE
Use Bash from $PATH

### DIFF
--- a/catimg
+++ b/catimg
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 ################################################################################
 # catimg script by Eduardo San Martin Morote aka Posva                         #


### PR DESCRIPTION
If you use "#!/usr/bin/env bash" instead then the PATH variable specifies where to look for "bash" first. Basically this makes it really easy for users to override the system bash version with a user installed bash version, for example through Homebrew.

Example:
```
#!/usr/bin/env bash
+
PATH="/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
=
Execution of /usr/local/bin/bash instead of /bin/bash because it is specified first.
```