### PR TITLE
Update README and RPM spec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ Homebrew
 ```
 brew install catimg
 ```
-archlinux
+Arch Linux
 ```
 yaourt -S catimg
+```
+Fedora 25 and later
+```
+dnf -y install catimg
 ```
 
 Building

--- a/catimg.spec
+++ b/catimg.spec
@@ -1,43 +1,37 @@
-Name:    catimg
-Version: 2.2
-Release: 1%{?dist}
-Summary: Print images in a terminal with 256 colors support
+Name:           catimg
+Version:        2.2.1
+Release:        1%{?dist}
+Summary:        Print images in a terminal with 256 colors support
 
+License:        MIT
+URL:            https://github.com/posva/catimg
+Source0:        https://github.com/posva/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 
-Group:   Applications/Multimedia
-License: MIT
-
-URL:     https://github.com/posva/catimg
-Source0: https://github.com/posva/%{name}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+BuildRequires:  cmake
+BuildRequires:  gcc
 
 %description
-Print images in a terminal with 256 colors support
-
-
-BuildRequires: cmake
-Requires:
-
+%{name} is a little program written in C with no dependencies that prints
+images in terminal. It supports JPEG, PNG and GIF formats.
 
 %prep
-%setup -q
-
+%autosetup
 
 %build
-%cmake .
-make %{?_smp_mflags}
-
+mkdir -p build
+pushd build
+%cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+%make_build
+popd
 
 %install
+pushd build
 %make_install
-
+popd
 
 %files
-/usr/bin/catimg*
+%license LICENSE
 %doc README.md
-
-
+%{_bindir}/%{name}
 
 %changelog
-* Sun Oct 04 2015  Eduardo San Martin Morote <i@posva.net> - 2.2
-* Fri Sep 18 2015 Mike Gerber <mike@sprachgewalt.de> - 2.0-1
-- Initial spec file


### PR DESCRIPTION
Hi,
catimg was added to the official Fedora repos. Today you can find it in Rawhide and at the latest within 7 days in Fedora 25 (stable). In case of any questions I'm the main contact (maintainer).