### PR TITLE
transparency corruption, 24-bit speed and quality

### DIFF
--- a/src/catimg.c
+++ b/src/catimg.c
@@ -7,6 +7,9 @@
 #include <signal.h>
 #define USAGE printf("Usage catimg [-h] [-w width] [-l loops] [-r resolution] img\nBy default w is the terminal width.\nLoops are only useful with GIF. A value of 1 means that the GIF will be displayed twice. A negative value means infinite looping.\nResolution must be 1 or 2. By default catimg checks for unicode support to use higher resolution\n")
 
+// Transparency threshold -- all pixels with alpha below 25%.
+#define TRANSP_ALPHA 64
+
 extern char *optarg;
 extern int optind;
 extern int optopt;
@@ -126,8 +129,8 @@ int main(int argc, char *argv[])
                     if (precision == 2) {
                         if (y < img.height - 1) {
                             const color_t* lowerPixel = &img.pixels[index + img.width];
-                            if (!upperPixel->a) { // first pixel is transparent
-                                if (!lowerPixel->a)
+                            if (upperPixel->a < TRANSP_ALPHA) { // first pixel is transparent
+                                if (lowerPixel->a < TRANSP_ALPHA)
                                     printf("\e[m ");
                                 else
                                     printf("\x1b[38;2;%d;%d;%dm\u2584",
@@ -135,7 +138,7 @@ int main(int argc, char *argv[])
                                            );
                                     // printf("\e[0;38;5;%um\u2584", bgCol);
                             } else {
-                                if (!lowerPixel->a)
+                                if (lowerPixel->a < TRANSP_ALPHA)
                                     printf("\x1b[38;2;%d;%d;%dm\u2580",
                                            upperPixel->r, upperPixel->g, upperPixel->b
                                            );
@@ -149,7 +152,7 @@ int main(int argc, char *argv[])
                                     /* printf("\e[38;5;%u;48;5;%um\u2580", fgCol, bgCol); */
                             }
                         } else { // this is the last line
-                            if (!upperPixel->a)
+                            if (upperPixel->a < TRANSP_ALPHA)
                                 printf("\e[m ");
                             else
                               printf("\x1b[38;2;%d;%d;%dm\u2580",

--- a/src/catimg.c
+++ b/src/catimg.c
@@ -96,7 +96,8 @@ int main(int argc, char *argv[])
         float sc = cols/(float)img.width;
         img_resize(&img, sc, sc);
     }
-    img_convert_colors(&img);
+    if (precision == 1)
+        img_convert_colors(&img);
     /*printf("Loaded %s: %ux%u. Console width: %u\n", file, img.width, img.height, cols);*/
     // For GIF
     if (img.frames > 1) {

--- a/src/catimg.c
+++ b/src/catimg.c
@@ -121,14 +121,12 @@ int main(int argc, char *argv[])
             for (y = 0; y < img.height; y += precision) {
                 for (x = 0; x < img.width; x++) {
                     index = y * img.width + x + offset;
-                    uint32_t fgCol = pixelToInt(&img.pixels[index]);
                     const color_t* upperPixel = &img.pixels[index];
                     if (precision == 2) {
                         if (y < img.height - 1) {
                             const color_t* lowerPixel = &img.pixels[index + img.width];
-                            uint32_t bgCol = pixelToInt(&img.pixels[index + img.width]);
-                            if (fgCol == 0xffff) { // first pixel is transparent
-                                if (bgCol == 0xffff)
+                            if (!upperPixel->a) { // first pixel is transparent
+                                if (!lowerPixel->a)
                                     printf("\e[m ");
                                 else
                                     printf("\x1b[38;2;%d;%d;%dm\u2584",
@@ -136,7 +134,7 @@ int main(int argc, char *argv[])
                                            );
                                     // printf("\e[0;38;5;%um\u2584", bgCol);
                             } else {
-                                if (bgCol == 0xffff)
+                                if (!lowerPixel->a)
                                     printf("\x1b[38;2;%d;%d;%dm\u2580",
                                            upperPixel->r, upperPixel->g, upperPixel->b
                                            );
@@ -150,7 +148,7 @@ int main(int argc, char *argv[])
                                     /* printf("\e[38;5;%u;48;5;%um\u2580", fgCol, bgCol); */
                             }
                         } else { // this is the last line
-                            if (fgCol == 0xffff)
+                            if (!upperPixel->a)
                                 printf("\e[m ");
                             else
                               printf("\x1b[38;2;%d;%d;%dm\u2580",
@@ -159,6 +157,7 @@ int main(int argc, char *argv[])
                             // printf("\e[38;5;%um\u2580", fgCol);
                         }
                     } else {
+                        uint32_t fgCol = pixelToInt(upperPixel);
                         if (fgCol == 0xffff)
                             printf("\e[m  ");
                         else

--- a/src/catimg.c
+++ b/src/catimg.c
@@ -133,13 +133,13 @@ int main(int argc, char *argv[])
                                 if (lowerPixel->a < TRANSP_ALPHA)
                                     printf("\e[m ");
                                 else
-                                    printf("\x1b[38;2;%d;%d;%dm\u2584",
+                                    printf("\x1b[0;38;2;%d;%d;%dm\u2584",
                                            lowerPixel->r, lowerPixel->g, lowerPixel->b
                                            );
                                     // printf("\e[0;38;5;%um\u2584", bgCol);
                             } else {
                                 if (lowerPixel->a < TRANSP_ALPHA)
-                                    printf("\x1b[38;2;%d;%d;%dm\u2580",
+                                    printf("\x1b[0;38;2;%d;%d;%dm\u2580",
                                            upperPixel->r, upperPixel->g, upperPixel->b
                                            );
                                          // printf("\e[0;38;5;%um\u2580", fgCol);
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
                             if (upperPixel->a < TRANSP_ALPHA)
                                 printf("\e[m ");
                             else
-                              printf("\x1b[38;2;%d;%d;%dm\u2580",
+                              printf("\x1b[0;38;2;%d;%d;%dm\u2580",
                                      upperPixel->r, upperPixel->g, upperPixel->b
                                      );
                             // printf("\e[38;5;%um\u2580", fgCol);

--- a/src/catimg.c
+++ b/src/catimg.c
@@ -131,13 +131,13 @@ int main(int argc, char *argv[])
                                 if (bgCol == 0xffff)
                                     printf("\e[m ");
                                 else
-                                    printf("\x1b[38;2;%d;%d;%dm\u2580",
+                                    printf("\x1b[38;2;%d;%d;%dm\u2584",
                                            lowerPixel->r, lowerPixel->g, lowerPixel->b
                                            );
                                     // printf("\e[0;38;5;%um\u2584", bgCol);
                             } else {
                                 if (bgCol == 0xffff)
-                                    printf("\x1b[48;2;%d;%d;%dm\u2580",
+                                    printf("\x1b[38;2;%d;%d;%dm\u2580",
                                            upperPixel->r, upperPixel->g, upperPixel->b
                                            );
                                          // printf("\e[0;38;5;%um\u2580", fgCol);
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
                             if (fgCol == 0xffff)
                                 printf("\e[m ");
                             else
-                              printf("\x1b[48;2;%d;%d;%dm\u2580",
+                              printf("\x1b[38;2;%d;%d;%dm\u2580",
                                      upperPixel->r, upperPixel->g, upperPixel->b
                                      );
                             // printf("\e[38;5;%um\u2580", fgCol);


### PR DESCRIPTION
Here's a bunch of fixes for high-resolution mode:
 * pixels at the edge of transparent regions were corrupted
 * despite using 24-bit codes, only 256 colors were actually used
 * the above also drastically improves speed
 * avoid fringes of color in very low alpha parts