### PR TITLE
Pull request issue #35 nanosleep

### DIFF
--- a/src/catimg.c
+++ b/src/catimg.c
@@ -153,8 +153,8 @@ int main(int argc, char *argv[])
                     req.tv_nsec = (long)(img.delays[frame - 1] * 10000000L);
                     nanosleep(&req, (struct timespec *)NULL);
                 } else {
-                  /*  req.tv_nsec = (long)(img.delays[img.frames - 1] * 100000000000L);
-                    nanosleep(&req, (struct timespec *)NULL); */
+                    req.tv_nsec = (long)(img.delays[img.frames - 1] * 10000000L);
+                   nanosleep(&req, (struct timespec *)NULL);
                 }
                 printf("\e[u");
             }


### PR DESCRIPTION
Was able to get nanosleep working

```
int main(int argc, char *argv[])
{
    init_hash_colors();
    image_t img;
    char *file;
    char *num;
    int c;
    struct timespec req;  // <-------------  
    
    req.tv_sec = 0;     // <-------------
    opterr = 0;
    uint32_t cols = 0, precision = 0;
    uint8_t convert = 0;
    uint8_t true_color = 1;
```
Declared the ``` timespec ```  struct above main in ``` catimg.c  ```, wasn't sure where you wanted it.
```
struct timespec {
    time_t tv_sec;  /* seconds */       
    long   tv_nsec; /* nanoseconds */   
};
```
I tested multiple gifs and provided them in the test-gifs directory, goku.gif is my only concern, as hes going super sayan way quicker with the nanosleep.

I checkout the gif in gimp and the background layer is labled as ``` Background (1000ms) ``` as where every other layer is formated such as ``` frame 1 (40ms) (combine) ```.  Not sure what the deal is. But besides for this, everything (all the other gifs I tested) appears to look very close to the same.