### PR TITLE
Fix floating point exception while using `-H`

### DIFF
--- a/src/catimg.c
+++ b/src/catimg.c
@@ -157,7 +157,7 @@ int main(int argc, char *argv[])
         scale_cols = cols / (float)img.width;
         img_resize(&img, scale_cols, scale_cols);
      } else if (rows > 0 && rows < img.height) {
-        scale_rows = (float)(rows * 2) / (float)img.height;
+        scale_rows = rows / (float)img.height;
         img_resize(&img, scale_rows, scale_rows);
     }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

Fix the floating point exception, it was simple enough.
Before, it tried to grow the image and I guess `img_resize` is not made for that. `wh` in `sh_image.c` ended up `0` since the scale ratio got well below 1.
