### PR TITLE
Add support for fonts with different aspect ratio

### DIFF
--- a/completion/_catimg
+++ b/completion/_catimg
@@ -44,6 +44,7 @@ _arguments \
   '-r[force the resolution of the image]: :->resolution' \
   '-t[disable true color and use 256 color instead]' \
   '-w[specify the width of the displayed image]' \
+  '-a[specify the aspect ratio multiplier of the font]' \
   '*: :_files' && ret=0
 
 [[ "$state" == 'resolution' ]] && _values 'resolution value' 1 2 && ret=0


### PR DESCRIPTION
The PR introduces `-a` argument that allows pre-scaling the image for non 2:1 fonts.
fixes #64

Interface may be worth bikeshedding, perhaps biasing it to be around 100 and not 1.0 would be useful so integer arguments can be used meaningfully.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No