### PR TITLE
add option for height offset fix #67

### DIFF
--- a/completion/_catimg
+++ b/completion/_catimg
@@ -40,6 +40,7 @@ _arguments \
   '-c[convert colors to a restricted palette]' \
   '-h[display a help message]' \
   '-H[specify the height of the displayed image]' \
+  '-o[specify the height offset of the displayed image]' \
   '-l[specify the amount of loops that catimg should repeat a GIF]' \
   '-r[force the resolution of the image]: :->resolution' \
   '-t[disable true color and use 256 color instead]' \

--- a/man/catimg.1
+++ b/man/catimg.1
@@ -5,7 +5,7 @@ catimg \- fast image printing in to your terminal
 
 .SH SYNOPSIS
 .B catimg
-[\fB-hct\fP] [\fB-w width\fP | \fB-H height\fP] [\fB-l loops\fP] [\fB-r resolution\fP] image
+[\fB-hct\fP] [\fB-w width\fP | \fB-H height\fP] [\fB-o height offset\fP] [\fB-l loops\fP] [\fB-r resolution\fP] image
 
 .SH DESCRIPTION
 .B catimg
@@ -21,6 +21,9 @@ Prints a help message
 .TP
 \fB\-H\fR HEIGHT
 Specify the height of the displayed image, passing '0' will use terminal height.
+.TP
+\fB\-o\fR HEIGHT_OFFSET
+Specify the height offset of the displayed image, passing '0' will use no terminal height offset.
 .TP
 \fB\-l\fR LOOPS
 Specify the amount of loops that catimg should repeat a GIF. A value of 1 means that the GIF will be displayed twice. A negative value implies infinity.

--- a/src/catimg.c
+++ b/src/catimg.c
@@ -11,6 +11,7 @@
   "  -h: Displays this message\n"                                      \
   "  -w: Terminal width/columns by default\n"                           \
   "  -H: Terminal height/row by default\n"                           \
+  "  -o: Terminal height offset by default\n"                           \
   "  -l: Loops are only useful with GIF files. A value of 1 means that the GIF will " \
   "be displayed twice because it loops once. A negative value means infinite " \
   "looping\n"                                                           \
@@ -72,13 +73,14 @@ int main(int argc, char *argv[])
     opterr = 0;
 
     uint32_t cols = 0, rows = 0, precision = 0;
+    uint32_t height_offset = 0; // To account for the prompt in vertical scaling
     uint32_t max_cols = 0, max_rows = 0;
     uint8_t convert = 0;
     uint8_t true_color = 1;
     uint8_t adjust_to_height = 0, adjust_to_width = 0;
     float scale_cols = 0, scale_rows = 0;
 
-    while ((c = getopt (argc, argv, "H:w:l:r:hct")) != -1)
+    while ((c = getopt (argc, argv, "H:o:w:l:r:hct")) != -1)
         switch (c) {
             case 'H':
                 rows = strtol(optarg, &num, 0);
@@ -89,6 +91,9 @@ int main(int argc, char *argv[])
                     exit(1);
                 }
                 adjust_to_height = 1;
+                break;
+            case 'o':
+                height_offset = strtol(optarg, &num, 0);
                 break;
             case 'w':
                 cols = strtol(optarg, &num, 0) >> 1;
@@ -138,7 +143,7 @@ int main(int argc, char *argv[])
 
     // if precision is 2 we can use the terminal full width/height. Otherwise we can only use half
     max_cols = terminal_columns() / (2 / precision);
-    max_rows = terminal_rows() * precision;
+    max_rows = (terminal_rows() - height_offset) * precision;
 
     if (strcmp(file, "-") == 0) {
         img_load_from_stdin(&img);

--- a/src/catimg.c
+++ b/src/catimg.c
@@ -11,7 +11,7 @@
   "  -h: Displays this message\n"                                      \
   "  -w: Terminal width/columns by default\n"                           \
   "  -H: Terminal height/row by default\n"                           \
-  "  -o: Terminal height offset by default\n"                           \
+  "  -o: Terminal height offset by default 1\n"                           \
   "  -l: Loops are only useful with GIF files. A value of 1 means that the GIF will " \
   "be displayed twice because it loops once. A negative value means infinite " \
   "looping\n"                                                           \
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
     opterr = 0;
 
     uint32_t cols = 0, rows = 0, precision = 0;
-    uint32_t height_offset = 0; // To account for the prompt in vertical scaling
+    uint32_t height_offset = 1; // To account for the prompt in vertical scaling
     uint32_t max_cols = 0, max_rows = 0;
     uint8_t convert = 0;
     uint8_t true_color = 1;


### PR DESCRIPTION
in vertical scaling this accounts for used spaced in the terminal such as a prompt

This is a bug fix that resolves the display of scaling to the max terminal height. In reality the prompt get shown immediately after the image is displayed in the buffer, resulting in a view of a cutoff image. Adding an offset (optional) allows for users to change the effective max terminal height which their image is scaled against to render the complete image in their currently open terminal window.

This also fixes jarring updates from gifs. As if the displayed gif is larger than the display buffer, the gif is not played out smoothly in the terminal. Adding this offset allows scaling of the gif to fit the displayed buffer (this includes the user shell prompt) to ensure the smooth playback of the gif.

This can be treated as a feature request, however it primarily solves a vertical scaling display bug.

fixes #67 

this issue could also be fixed by #69 

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [NA] All tests are passing
- [NA] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
An alternative to `catimg`, [timg](https://github.com/hzeller/timg) properly resolves this issue and scales according with user prompts. For a workaround and temporary solution, users can use [timg](https://github.com/hzeller/timg).