### PR TITLE
Update CMake minimum required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 project(catimg)
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)


### PR DESCRIPTION
CMake 4 no longer supports versions older than 3.5, and versions between 3.5-3.10 are deprecated. This PR updates the minimum required version to 3.10 to ensure compatibility with modern CMake versions.

## Background

This issue is already affecting NixOS users (see https://github.com/NixOS/nixpkgs/issues/449801) and will likely impact other distributions as they upgrade to CMake 4.x in the coming months.

## Changes

- Updated `cmake_minimum_required(VERSION 2.8)` to `cmake_minimum_required(VERSION 3.10)`

## Testing

This change has been tested and builds successfully with both CMake 3.x and CMake 4.x.